### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Example usage:
 
 	import (
 		"fmt"
-		gt "github.com/bas24/translategooglefree"
+		gt "github.com/bas24/googletranslatefree"
 	)
 
 	func main(){


### PR DESCRIPTION
s16: must import as folder name. Fixed typo in example.