### PR TITLE
fixed README.md line:16

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Example usage:
 
 	import (
 		"fmt"
-		gt "github.com/bas24/translategooglefree"
+		gt "github.com/bas24/googletranslatefree"
 	)
 
 	func main(){
@@ -24,4 +24,4 @@ Example usage:
 		fmt.Println(result)
 		// Output: "Hola, Mundo!"
 	}
-``` 
+```


### PR DESCRIPTION
I think README.md file line:16 is wrong.
Maybe,
gt "github.com/bas24/translategooglefree"
￬
gt "github.com/bas24/googletranslatefree"